### PR TITLE
Add sandwich ordering interface

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,38 +1,21 @@
 .App {
-  text-align: center;
+  font-family: sans-serif;
+  padding: 2rem;
+  text-align: left;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+form {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  gap: 1rem;
+  max-width: 300px;
 }
 
-.App-link {
-  color: #61dafb;
+fieldset {
+  border: 1px solid #ccc;
+  padding: 1rem;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+button {
+  width: 150px;
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,23 +1,84 @@
-import logo from './logo.svg';
+import { useState } from 'react';
 import './App.css';
 
 function App() {
+  const [bread, setBread] = useState('Wheat');
+  const [protein, setProtein] = useState('Turkey');
+  const [extras, setExtras] = useState({
+    lettuce: false,
+    tomato: false,
+    cheese: false,
+  });
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleExtrasChange = (e) => {
+    const { name, checked } = e.target;
+    setExtras(prev => ({ ...prev, [name]: checked }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  const extrasList = Object.keys(extras).filter(k => extras[k]).join(', ') || 'None';
+  const summary = `Bread: ${bread}, Protein: ${protein}, Extras: ${extrasList}`;
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-         CAACACCACAC 
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>Order a Sandwich</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Bread:
+          <select value={bread} onChange={e => setBread(e.target.value)}>
+            <option>Wheat</option>
+            <option>White</option>
+            <option>Rye</option>
+          </select>
+        </label>
+        <label>
+          Protein:
+          <select value={protein} onChange={e => setProtein(e.target.value)}>
+            <option>Turkey</option>
+            <option>Ham</option>
+            <option>Veggie</option>
+          </select>
+        </label>
+        <fieldset>
+          <legend>Extras</legend>
+          <label>
+            <input
+              type="checkbox"
+              name="lettuce"
+              checked={extras.lettuce}
+              onChange={handleExtrasChange}
+            />
+            Lettuce
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              name="tomato"
+              checked={extras.tomato}
+              onChange={handleExtrasChange}
+            />
+            Tomato
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              name="cheese"
+              checked={extras.cheese}
+              onChange={handleExtrasChange}
+            />
+            Cheese
+          </label>
+        </fieldset>
+        <button type="submit">Place Order</button>
+      </form>
+      {submitted && (
+        <p data-testid="summary">{summary}</p>
+      )}
     </div>
   );
 }

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders sandwich order heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/order a sandwich/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- implement a simple sandwich ordering form in React
- add minimal styling
- update tests to reflect new UI

## Testing
- `npm test -- --watchAll=false`
