### PR TITLE
Enhance sandwich order UI

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,7 +1,18 @@
+
 .App {
   font-family: sans-serif;
   padding: 2rem;
   text-align: left;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.sandwich-img {
+  width: 100%;
+  max-height: 300px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
 }
 
 form {
@@ -14,8 +25,72 @@ form {
 fieldset {
   border: 1px solid #ccc;
   padding: 1rem;
+  border-radius: 4px;
 }
 
 button {
   width: 150px;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  border: none;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #007bff;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -10,6 +10,7 @@ function App() {
     cheese: false,
   });
   const [submitted, setSubmitted] = useState(false);
+  const [readyToOrder, setReadyToOrder] = useState(false);
 
   const handleExtrasChange = (e) => {
     const { name, checked } = e.target;
@@ -27,6 +28,11 @@ function App() {
   return (
     <div className="App">
       <h1>Order a Sandwich</h1>
+      <img
+        className="sandwich-img"
+        src="https://images.unsplash.com/photo-1606755962778-209909d818c6?auto=format&fit=crop&w=800&q=80"
+        alt="Delicious sandwich"
+      />
       <form onSubmit={handleSubmit}>
         <label>
           Bread:
@@ -74,7 +80,19 @@ function App() {
             Cheese
           </label>
         </fieldset>
-        <button type="submit">Place Order</button>
+        <div className="toggle">
+          <label className="switch">
+            <input
+              type="checkbox"
+              aria-label="Ready to Order"
+              checked={readyToOrder}
+              onChange={() => setReadyToOrder(!readyToOrder)}
+            />
+            <span className="slider"></span>
+          </label>
+          <span>Ready to Order</span>
+        </div>
+        <button type="submit" disabled={!readyToOrder}>Place Order</button>
       </form>
       {submitted && (
         <p data-testid="summary">{summary}</p>

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,8 +1,18 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
 test('renders sandwich order heading', () => {
   render(<App />);
   const heading = screen.getByText(/order a sandwich/i);
   expect(heading).toBeInTheDocument();
+});
+
+test('order button disabled until toggle is checked', () => {
+  render(<App />);
+  const button = screen.getByRole('button', { name: /place order/i });
+  expect(button).toBeDisabled();
+  const toggle = screen.getByLabelText(/ready to order/i);
+  userEvent.click(toggle);
+  expect(button).toBeEnabled();
 });


### PR DESCRIPTION
## Summary
- add sandwich image and toggle to enable ordering
- improve form and button styles
- test toggle behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688abaf8ac1c832a934dcffb26d1ad25